### PR TITLE
check both args of wfopen instead of one twice.

### DIFF
--- a/safileio.c
+++ b/safileio.c
@@ -236,7 +236,7 @@ SAFile SAUtf8WFOpen( const char *pszFilename, const char *pszAccess )
     const wchar_t *pwszFileName, *pwszAccess;
     pwszFileName = Utf8ToWideChar( pszFilename );
     pwszAccess = Utf8ToWideChar( pszAccess );
-    if( pwszFileName != NULL && pwszFileName != NULL)
+    if( pwszFileName != NULL && pwszAccess != NULL)
     {
         file = (SAFile) _wfopen( pwszFileName, pwszAccess );
     }


### PR DESCRIPTION
This bug was previously reported as http://bugzilla.maptools.org/show_bug.cgi?id=2744.

This bug shows up with cppcheck:

> ubuntu18:~/work/shapelib-1.4.1$ cppcheck --enable=style safileio.c
> Checking safileio.c ...
> Checking safileio.c: DISABLE_CVSID...
> Checking safileio.c: SHAPELIB_DLLEXPORT...
> Checking safileio.c: SHPAPI_UTF8_HOOKS...
> Checking safileio.c: SHPAPI_UTF8_HOOKS;SHPAPI_WINDOWS...
> [safileio.c:239] -> [safileio.c:239]: (style) Same expression on both sides of '&&'.
> Checking safileio.c: SHPAPI_WINDOWS...
> Checking safileio.c: USE_CPL...
> Checking safileio.c: USE_DBMALLOC...
> Checking safileio.c: USE_GCC_VISIBILITY_FLAG...
> Checking safileio.c: WIN32;_WIN32;__WIN32__...
> Checking safileio.c: __GNUC__... 